### PR TITLE
Revert GTK 4.10

### DIFF
--- a/data/settings.json
+++ b/data/settings.json
@@ -1,1 +1,1 @@
-{"mono_font":"Consolas 12"}
+{"mono_font":"Cascadia Mono 10"}

--- a/src/view/Cargo.toml
+++ b/src/view/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 model = { path = "../model" }
 util = { path = "../util" }
 adw = { package = "libadwaita", version = "0.3.1" }
-gtk = { package = "gtk4", version = "0.6.2" , features = ["v4_10"]}
+gtk = { package = "gtk4", version = "0.6.2" }
 sourceview5 = "0.6.0"
 glib = "0.17.0"
 dark-light = "0.2.3"

--- a/src/view/Cargo.toml
+++ b/src/view/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 model = { path = "../model" }
 util = { path = "../util" }
 adw = { package = "libadwaita", version = "0.3.1" }
-gtk = { package = "gtk4", version = "0.6.2" }
+gtk = { package = "gtk4", version = "0.6.2" , features = ["v4_10"]}
 sourceview5 = "0.6.0"
 glib = "0.17.0"
 dark-light = "0.2.3"

--- a/src/view/Cargo.toml
+++ b/src/view/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 model = { path = "../model" }
 util = { path = "../util" }
 adw = { package = "libadwaita", version = "0.3.1" }
-gtk = { package = "gtk4", version = "0.6.2", features = ["v4_10"] }
+gtk = { package = "gtk4", version = "0.6.2" }
 sourceview5 = "0.6.0"
 glib = "0.17.0"
 dark-light = "0.2.3"

--- a/src/view/res/mono_style.css
+++ b/src/view/res/mono_style.css
@@ -1,1 +1,1 @@
-.monospace { font: 12pt "Consolas" }
+.monospace { font: 10pt "Cascadia Mono" }

--- a/src/view/src/adw_app.rs
+++ b/src/view/src/adw_app.rs
@@ -328,7 +328,7 @@ impl AdwApp {
 
     fn connect_file_open(window: AppWindow) {
         Self::connect_simple_action(window.clone(), "file-open", move |_, _| {
-            // TODO: Investigate why this filter does not work
+            // TODO: Investigate why this filter does not work (maybe only an issue on Windows native)
             let filter = FileFilter::new();
             filter.add_pattern("*.s");
             filter.add_pattern("*.asm");


### PR DESCRIPTION
In a previous chain of commits, the project was updated to use GTK 4.10 features, as v4.10 deprecated many existing features. However, since v4.10 is not yet supported by default on many systems, I have refactored parts of this project's code to be compatible with older versions of GTK.

The GTK 4.10 code is still there, just commented out. This will make future migration easier.

There are possibly some conflicts with newer libadwaita versions which may prevent startup on older Linux systems. I have yet to fully investigate this.